### PR TITLE
The coding standard name is renamed.

### DIFF
--- a/DrupalCodingStandard.sublime-build
+++ b/DrupalCodingStandard.sublime-build
@@ -1,4 +1,4 @@
 {
-  "cmd": ["phpcs", "--report=emacs", "--standard=DrupalCodingStandard", "--extensions=php,module,inc,install,test,profile,theme", "$file"],
+  "cmd": ["phpcs", "--report=emacs", "--standard=Drupal", "--extensions=php,module,inc,install,test,profile,theme", "$file"],
   "file_regex": "^(.*):(.*):(.*):(.*)$"
 }


### PR DESCRIPTION
In the drupalcs module on Drupal.org, the coding standard name has been renamed from DrupalCodingStandard to Drupal.
